### PR TITLE
Increase 'Mongoid' and 'ActiveSupport' version and little more

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
-        mongoid-version: ['6.2.0', '6.3.0', '6.4.0', '7.0.0', '7.1.0', '8.0.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        mongoid-version: ['6.2.0', '6.3.0', '6.4.0', '7.0.0', '7.1.0', '8.0.0', '8.1.0']
 
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem "request_store", require: false
 
 group :development do
   gem "simplecov", require: false
-  gem "pry-nav", "~> 0.2.4"
+  gem "pry", "~> 0.14"
+  gem "pry-nav", "~> 1.0"
   gem "standard", "~> 0.1.0"
   gem "rubocop"
   gem "rubocop-performance"

--- a/lib/mongoid/userstamps/version.rb
+++ b/lib/mongoid/userstamps/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Userstamps
-    VERSION = "3.4.1"
+    VERSION = "3.5.0"
   end
 end

--- a/mongoid-userstamps.gemspec
+++ b/mongoid-userstamps.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.post_install_message = File.read("UPGRADING") if File.exist?("UPGRADING")
 
-  s.add_dependency "mongoid", ">= 5.0.0", "<= 8.0"
-  s.add_dependency "activesupport", ">= 4.2.0", "<= 7.1"
+  s.add_dependency "mongoid", ">= 5.0.0", "<= 9.0"
+  s.add_dependency "activesupport", ">= 4.2.0", "<= 7.2"
 end


### PR DESCRIPTION
This PR aims to validate the increased compatibility of the mongoid-userstamps gem with newer versions of Mongoid and ActiveSupport. The updates include expanding support to newer Ruby versions, adding compatibility with Mongoid 8.1.0, and updating dependencies for ActiveSupport to support up to version 7.2. Additionally, some development dependencies have been updated to their latest versions.

Solves #2 .